### PR TITLE
feat: Add weights to histogram for Drell-Yan example

### DIFF
--- a/examples/plot_mass_spectrum.py
+++ b/examples/plot_mass_spectrum.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         .joinpath("drell-yan_output")
         .joinpath("Events")
         .joinpath("run_01")
-        .joinpath("unweighted_events.lhe")
+        .joinpath("unweighted_events.lhe.gz")
     )
     _weights = []
     for event in pylhe.readLHE(lhe_path):

--- a/examples/plot_mass_spectrum.py
+++ b/examples/plot_mass_spectrum.py
@@ -67,6 +67,16 @@ if __name__ == "__main__":
     ax.semilogy()
     ax.set_xlabel(r"$\ell\ell$ pair mass [GeV]")
     ax.set_ylabel(f"Count / [{bin_width} GeV]")
+
+    xtick_width = 10  # GeV
+    ax.set_xticks(
+        np.arange(
+            hist_range[0] + int(xtick_width / 2),
+            hist_range[1] + int(xtick_width / 2),
+            xtick_width,
+        )
+    )
+
     # ax.set_title("Drell-Yan invariant mass spectrum")
     ax.set_title("Drell-Yan")
     fig.savefig("drell-yan-spectrum.png")

--- a/examples/plot_mass_spectrum_ROOT.py
+++ b/examples/plot_mass_spectrum_ROOT.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
         .joinpath("drell-yan_output")
         .joinpath("Events")
         .joinpath("run_01")
-        .joinpath("unweighted_events.lhe")
+        .joinpath("unweighted_events.lhe.gz")
     )
     for event in pylhe.readLHE(lhe_path):
         hist_1.Fill(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 hist[plot]~=2.2.1
-pylhe~=0.2.0
+pylhe~=0.2.1


### PR DESCRIPTION
```
* Use hist.Hist's weight storage to give histogram entries event weights
* Require minimum release of pylhe v0.2.1 for reading .gz LHE files
```