### PR TITLE
feat: Add simple MadGraph5 config generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,9 @@ dmypy.json
 # ignore binaries
 *.png
 
+# ignore VSCode configs
+.vscode
+
 # MadGraph5
 py.py
 drell-yan_output/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
     - id: check-added-large-files
     - id: check-case-conflict
@@ -15,30 +15,30 @@ repos:
     - id: mixed-line-ending
     - id: trailing-whitespace
 
--   repo: https://github.com/psf/black
-    rev: 20.8b1
-    hooks:
-    - id: black
-
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.0
-    hooks:
-    - id: flake8
-
 -   repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.9.2
     hooks:
     - id: isort
 
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.11.0
+    rev: v2.21.2
     hooks:
     - id: pyupgrade
 
+-   repo: https://github.com/psf/black
+    rev: 21.7b0
+    hooks:
+    - id: black
+
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+    - id: flake8
+
 -   repo: https://github.com/nbQA-dev/nbQA
-    rev: 0.5.9
+    rev: 1.0.0
     hooks:
     - id: nbqa-black
-      additional_dependencies: [black==20.8b1]
+      additional_dependencies: [black==21.7b0]
     - id: nbqa-pyupgrade
-      additional_dependencies: [pyupgrade==2.11.0]
+      additional_dependencies: [pyupgrade==2.21.2]

--- a/configs/json/drell-yan.json
+++ b/configs/json/drell-yan.json
@@ -1,0 +1,10 @@
+{
+  "type": "madgraph5",
+  "process": "p p > l+ l-",
+  "output": "drell-yan",
+  "options": {
+    "shower": "Pythia8",
+    "nevents": 1000000
+  },
+  "version": "0.1.0"
+}

--- a/configs/madgraph5/drell-yan.mg5
+++ b/configs/madgraph5/drell-yan.mg5
@@ -1,0 +1,7 @@
+generate p p > l+ l-
+output drell-yan_output
+launch drell-yan_output
+  # Use PYTHIA8 for the shower/hadronization
+  shower=Pythia8
+  # Generate 1.0e+06 events
+  set nevents 1000000

--- a/generate_config.py
+++ b/generate_config.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+import click
+
+
+def json_to_mg5(config):
+    mg5_str = f"generate {config['process']}"
+    mg5_str += f"\noutput {config['output']}_output"
+    mg5_str += f"\nlaunch {config['output']}_output"
+
+    options = config["options"]
+    if "shower" in options:
+        mg5_str += "\n  # Use PYTHIA8 for the shower/hadronization"
+        mg5_str += f"\n  shower={options['shower']}"
+    nevents = options.get("nevents", 1000)
+    mg5_str += f"\n  # Generate {nevents:.1e} events"
+    mg5_str += f"\n  set nevents {nevents}"
+    mg5_str += "\n"
+
+    return mg5_str
+
+
+@click.command()
+@click.option(
+    "-c",
+    "--config",
+    "config_path",
+    help="Path to JSON configuration.",
+)
+def generate_config(config_path):
+    config_path = Path().cwd().joinpath(config_path)
+    with open(config_path, "r") as config_file:
+        config = json.load(config_file)
+
+    if config["type"] == "madgraph5":
+        output_config = json_to_mg5(config)
+        file_extension = ".mg5"
+
+    out_path = (
+        Path()
+        .cwd()
+        .joinpath("configs", config["type"], config["output"] + file_extension)
+    )
+    with open(out_path, "w") as outfile:
+        outfile.write(output_config)
+
+
+if __name__ == "__main__":
+    generate_config()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 hist[plot]~=2.2.1
 pylhe~=0.2.1
+click~=8.0.1


### PR DESCRIPTION
Add ability to generate simple MadGraph5 script files from a configuration file

```
* Add script to generate MadGraph5 configuration files from JSON configs
* Add example configs for Drell-Yan
* Add click to requirements
* Add vscode to ignores
* Update pre-commit hooks
```