### PR TITLE
chore: Add processing percentage status reporting to logs

### DIFF
--- a/bluewaters/drell-yan/momemta.pbs
+++ b/bluewaters/drell-yan/momemta.pbs
@@ -54,7 +54,6 @@ aprun \
     --clearenv \
     --image="${SHIFTER_IMAGE}" \
     --volume="${OUTPUT_PATH}":/root/data \
-    --volume="${USER_SCRATCH}/${PHYSICS_PROCESS}":"${USER_SCRATCH}/${PHYSICS_PROCESS}" \
     --volume=/mnt/a/"${HOME}":/mnt/a/"${HOME}" \
     --workdir=/root/data \
     -- /bin/bash -c 'source scl_source enable devtoolset-8 && \

--- a/momemta/llbb/topology_llbb.cxx
+++ b/momemta/llbb/topology_llbb.cxx
@@ -132,6 +132,10 @@ int main(int argc, char** argv) {
     // Instantiate MoMEMta using a **frozen** configuration
     MoMEMta weight(configuration.freeze());
 
+    // c.f. https://root.cern.ch/doc/v624/classTTreeReader.html#abe0530cfddbf50d5266d3d9ebb68972b
+    int totalNEvents = myReader.GetEntries(true);
+    int fractionOfEvents = totalNEvents / 20;
+
     int counter = 0;
     while (myReader.Next()) {
         /*
@@ -177,8 +181,8 @@ int main(int argc, char** argv) {
         out_tree->Fill();
 
         ++counter;
-        if (counter % 1000 == 0)
-            std::cout << "calculated weights for " << counter << " events\n";
+        if (counter % fractionOfEvents == 0)
+            std::cout << "calculated weights for " << counter << " events (" << counter*100/totalNEvents << "% of " << totalNEvents << " events)\n";
 
     }
     std::cout << "calculated weights for " << counter << " events\n";

--- a/preprocessing/scripts/SimpleAna.py
+++ b/preprocessing/scripts/SimpleAna.py
@@ -102,13 +102,17 @@ if __name__ == "__main__":
 
     # Loop through all events in chain
     print("Processing events")
+    total_nevents = chain.GetEntries()
+    fraction_of_events = int(total_nevents / 20)
     entry = 0
 
     for event in chain:
         entry += 1
 
-        if entry != 0 and entry % 10000 == 0:
-            print(f"{entry} events processed")
+        if entry % fraction_of_events == 0:
+            print(
+                f"{entry} events processed ({int(entry*100/total_nevents)}% of {total_nevents} events)"
+            )
             sys.stdout.flush()
 
         # wrapper around Delphes events to make some things easier
@@ -121,11 +125,10 @@ if __name__ == "__main__":
         # Require two leptons in the event that pass event_cuts
         if len(delphes_event.leptons) < 2:
             continue
-        if len(delphes_event.btags) < 2:
-            continue
 
         event_selection.fill(delphes_event, weight)
 
+    print(f"{entry} events processed")
     all_events.write()
     event_selection.write()
 

--- a/preprocessing/scripts/SimpleAna.py
+++ b/preprocessing/scripts/SimpleAna.py
@@ -125,6 +125,8 @@ if __name__ == "__main__":
         # Require two leptons in the event that pass event_cuts
         if len(delphes_event.leptons) < 2:
             continue
+        if len(delphes_event.btags) < 2:
+            continue
 
         event_selection.fill(delphes_event, weight)
 


### PR DESCRIPTION
```
* Add printing to logs after every 5% of the events have been processed for preprocessing and MoMEMta workflows
   - Note need for Bool_t force to be set to true for TTreeReader.GetEntries
* Remove unsupported volume mount point from MoMEMta Blue Waters PBS script
```