### PR TITLE
chore: Ensure submission scripts have modern Bash

### DIFF
--- a/bluewaters/run_delphes.sh
+++ b/bluewaters/run_delphes.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
+if [ "${BASH_VERSION:0:1}" -lt 4 ]; then
+    echo "ERROR: This script uses Bash version 4.0+ syntax. Your Bash version is ${BASH_VERSION} which is too old."
+    echo "       Run: 'module load bash' to get a modern version on Blue Waters."
+    exit 1
+fi
+
 PROCESS_DIRECTORY="${1:-drell-yan}"
 qsub "${PROCESS_DIRECTORY}/delphes.pbs"

--- a/bluewaters/run_madgraph5.sh
+++ b/bluewaters/run_madgraph5.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ "${BASH_VERSION:0:1}" -lt 4 ]; then
+    echo "ERROR: This script uses Bash version 4.0+ syntax. Your Bash version is ${BASH_VERSION} which is too old."
+    echo "       Run: 'module load bash' to get a modern version on Blue Waters."
+    exit 1
+fi
+
 PROCESS_DIRECTORY="${1:-drell-yan}"
 RANDOM_SEED=300
 qsub "${PROCESS_DIRECTORY}/madgraph5.pbs"

--- a/bluewaters/run_momemta.sh
+++ b/bluewaters/run_momemta.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
+if [ "${BASH_VERSION:0:1}" -lt 4 ]; then
+    echo "ERROR: This script uses Bash version 4.0+ syntax. Your Bash version is ${BASH_VERSION} which is too old."
+    echo "       Run: 'module load bash' to get a modern version on Blue Waters."
+    exit 1
+fi
+
 PROCESS_DIRECTORY="${1:-drell-yan}"
 qsub "${PROCESS_DIRECTORY}/momemta.pbs"

--- a/bluewaters/run_preprocessing.sh
+++ b/bluewaters/run_preprocessing.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
+if [ "${BASH_VERSION:0:1}" -lt 4 ]; then
+    echo "ERROR: This script uses Bash version 4.0+ syntax. Your Bash version is ${BASH_VERSION} which is too old."
+    echo "       Run: 'module load bash' to get a modern version on Blue Waters."
+    exit 1
+fi
+
 PROCESS_DIRECTORY="${1:-drell-yan}"
 qsub "${PROCESS_DIRECTORY}/preprocessing.pbs"


### PR DESCRIPTION
For whatever reasons Blue Waters is still running a default version of Bash on the login nodes that is Bash v3.X (for context Bash v4.0 was released in 2009). This PR warns the user if they are running the default version that they won't be able to use modern syntax and gives instructions on how to load a version of Bash v4.0 (which for Blue Waters is about as modern as you can hope so good enough :+1:)

```
* Add check on Bash version in submission scripts and warn user and exit 1 if the version of Bash is not at least v4.0
   - Bash v4.x+ has different syntax for what is a valid for loop compared to v3.0
```