### PR TITLE
feat: Parallelize MadGraph5 + PYTHIA8 running

### DIFF
--- a/bluewaters/drell-yan/madgraph5.pbs
+++ b/bluewaters/drell-yan/madgraph5.pbs
@@ -5,7 +5,7 @@
 #PBS -l nodes=1:ppn=8:xk
 
 # Set the wallclock time
-#PBS -l walltime=24:00:00
+#PBS -l walltime=6:00:00
 
 # Use shifter queue
 #PBS -l gres=shifter
@@ -17,24 +17,28 @@
 #PBS -e "${PBS_JOBNAME}.${PBS_JOBID}.err"
 #PBS -o "${PBS_JOBNAME}.${PBS_JOBID}.out"
 
-# Set email notification on termination or abort
-#PBS -m ea
+# Set email notification on termination (e) or abort (a)
+#PBS -m a
 #PBS -M matthew.feickert@cern.ch
 
 # Set allocation to charge
 #PBS -A bbdz
 
-# Ensure shifter enabled
-module load shifter
+# RANDOM_SEED passed through by qsub -v in run_madgraph.sh
+if [ -z "${RANDOM_SEED}" ]; then
+  RANDOM_SEED=${1:-999}
+fi
 
 PHYSICS_PROCESS="drell-yan_llbb"
 USER_SCRATCH="/mnt/c/scratch/sciteam/${USER}"
 OUTPUT_BASE_PATH="${USER_SCRATCH}/${PHYSICS_PROCESS}/${PBS_JOBNAME}"
-OUTPUT_PATH="${OUTPUT_BASE_PATH}/${PBS_JOBID}"
+OUTPUT_PATH="${OUTPUT_BASE_PATH}/${RANDOM_SEED}_${PBS_JOBID}"
 mkdir -p "${OUTPUT_PATH}"
 
 CODE_BASE_PATH="/mnt/a/${HOME}/MadGraph5-simulation-configs"
-RANDOM_SEED=300
+
+# Ensure shifter enabled
+module load shifter
 
 # $HOME is /u/sciteam/${USER}
 SHIFTER_IMAGE="neubauergroup/bluewaters-mg5_amc:3.1.1"


### PR DESCRIPTION
This PR parallelizes the simulation of MadGraph5 + PYTHIA8 by assigning each job a unique random seed to use for MadGraph5 that is properly spaced to avoid MadGraph having its seed change and wander into another job's seed area. The random seed are passed to each PBS job environment injection via `qsub -v` (this is just how `qsub` does things)

example:

```console
qsub -v RANDOM_SEED=1000 drell-yan/madgraph5.pbs"
```

would make the environmental variable `RANDOM_SEED` available inside of the PBS job and it would have value `1000`.

From `man qsub`:

```
       -v variable_list
               Expands the list of environment variables that are exported to the job.

               In addition to the variables described in the "Description" section above, variable_list names environment variables from the qsub command environment which are made available to the
               job when it executes.  The variable_list is a comma separated list of strings of the form variable or variable=value.  These variables and their values are passed to the job.

```

```
* Determine the number of distributed jobs to launch from the total number of events for simulation and the events per job.
   - Each job is given its own sequential random seed that is properly spaced so that MadGraph won't wander into that seed region.
   - It is easier to set the number of events per job than the number of jobs as it is easier to have a mental model for how long a set amount of events takes to process for each physics process
   - Default to 10^6 total events
* Pass the random seed to each job with qsub -v (variable_list) which injects that into the runtime environment of the job as the env variable RANDOM_SEED
* Add security check if RANDOM_SEED is not set
* Add the RANDOM_SEED for each job to its output name
```