### PR TITLE
feat: Parallelize MoMEMta processing

### DIFF
--- a/bluewaters/drell-yan/momemta.pbs
+++ b/bluewaters/drell-yan/momemta.pbs
@@ -27,7 +27,7 @@
 # Ensure shifter enabled
 module load shifter
 
-TOPOLOGY="ll"
+TOPOLOGY="llbb"
 # PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"
 PHYSICS_PROCESS="drell-yan"
 INPUT_JOBID="12513059.bw"

--- a/bluewaters/drell-yan/momemta.pbs
+++ b/bluewaters/drell-yan/momemta.pbs
@@ -5,7 +5,7 @@
 #PBS -l nodes=1:ppn=8:xk
 
 # Set the wallclock time
-#PBS -l walltime=48:00:00
+#PBS -l walltime=2:00:00
 
 # Use shifter queue
 #PBS -l gres=shifter
@@ -17,8 +17,8 @@
 #PBS -e "${PBS_JOBNAME}.${PBS_JOBID}.err"
 #PBS -o "${PBS_JOBNAME}.${PBS_JOBID}.out"
 
-# Set email notification on termination or abort
-#PBS -m ea
+# Set email notification on termination (e) or abort (a)
+#PBS -m a
 #PBS -M matthew.feickert@cern.ch
 
 # Set allocation to charge
@@ -27,9 +27,10 @@
 # Ensure shifter enabled
 module load shifter
 
-TOPOLOGY="llbb"
-PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"
-INPUT_JOBID="12509866.bw"
+TOPOLOGY="ll"
+# PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"
+PHYSICS_PROCESS="drell-yan"
+INPUT_JOBID="12513059.bw"
 CODE_BASE_PATH="/mnt/a/${HOME}/MadGraph5-simulation-configs"
 
 USER_SCRATCH="/mnt/c/scratch/sciteam/${USER}"
@@ -41,11 +42,20 @@ mkdir -p "${OUTPUT_PATH}"
 SHIFTER_IMAGE="neubauergroup/bluewaters-momemta:1.0.1"
 shifterimg pull "${SHIFTER_IMAGE}"
 
-# INPUT_PATH="${USER_SCRATCH}/${PHYSICS_PROCESS}/preprocessing/${INPUT_JOBID}/preprocessing_output_10e4.root"
 INPUT_PATH="${USER_SCRATCH}/${PHYSICS_PROCESS}/preprocessing/${INPUT_JOBID}/preprocessing/preprocessing_output.root"
 
 OUTPUT_FILE="${OUTPUT_PATH}/momemta_weights.root"
 
+# NUMBER_OF_STEPS passed through by qsub -v in run_momemta.sh
+if [ -z "${NUMBER_OF_STEPS}" ]; then
+  NUMBER_OF_STEPS=${1:-999}
+fi
+# STEP_NUMBER passed through by qsub -v in run_momemta.sh
+if [ -z "${STEP_NUMBER}" ]; then
+  STEP_NUMBER=${1:-999}
+fi
+
+# FIXME: There is a huge amount of copying being done in the container which is not great
 aprun \
   --bypass-app-transfer \
   --pes-per-node 1 \
@@ -59,5 +69,9 @@ aprun \
     -- /bin/bash -c 'source scl_source enable devtoolset-8 && \
         export PATH="/usr/local/venv/bin:${PATH}" && \
         printf "\n# printenv:\n" && printenv && printf "\n\n" && \
-        cd '"${CODE_BASE_PATH}"'/momemta/'"${TOPOLOGY}"' && \
-        bash run_momemta.sh '"${INPUT_PATH}"' '"${OUTPUT_FILE}"
+        mkdir -p momemta/'"${PHYSICS_PROCESS}"' && \
+        mkdir -p configs/momemta/ && \
+        cp -r '"${CODE_BASE_PATH}"'/momemta/'"${PHYSICS_PROCESS}"'/ momemta/ && \
+        cp -r '"${CODE_BASE_PATH}"'/configs/momemta/ configs/ && \
+        cd momemta/'"${PHYSICS_PROCESS}"' && \
+        bash run_momemta.sh '"${INPUT_PATH}"' '"${OUTPUT_FILE}"' '"${NUMBER_OF_STEPS}"' '"${STEP_NUMBER}"

--- a/bluewaters/drell-yan/momemta.pbs
+++ b/bluewaters/drell-yan/momemta.pbs
@@ -28,8 +28,7 @@
 module load shifter
 
 TOPOLOGY="llbb"
-# PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"
-PHYSICS_PROCESS="drell-yan"
+PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"
 INPUT_JOBID="12513059.bw"
 CODE_BASE_PATH="/mnt/a/${HOME}/MadGraph5-simulation-configs"
 

--- a/bluewaters/run_momemta.sh
+++ b/bluewaters/run_momemta.sh
@@ -9,7 +9,6 @@ fi
 PROCESS_DIRECTORY="${1:-drell-yan}"
 
 NUMBER_OF_JOBS=200
-# Submit jobs
 echo "# Submitting ${NUMBER_OF_JOBS} jobs"
 echo ""
 for n_job in $(seq 0 $((${NUMBER_OF_JOBS}-1)))

--- a/bluewaters/run_momemta.sh
+++ b/bluewaters/run_momemta.sh
@@ -7,4 +7,18 @@ if [ "${BASH_VERSION:0:1}" -lt 4 ]; then
 fi
 
 PROCESS_DIRECTORY="${1:-drell-yan}"
-qsub "${PROCESS_DIRECTORY}/momemta.pbs"
+
+NUMBER_OF_JOBS=200
+# Submit jobs
+echo "# Submitting ${NUMBER_OF_JOBS} jobs"
+echo ""
+for n_job in $(seq 0 $((${NUMBER_OF_JOBS}-1)))
+do
+    # qsub -v: comma separated list of strings of the form variable or variable=value.
+    qsub -v NUMBER_OF_STEPS="${NUMBER_OF_JOBS}",STEP_NUMBER="${n_job}" "${PROCESS_DIRECTORY}/momemta.pbs"
+done
+echo ""
+echo "# Submitted ${NUMBER_OF_JOBS} jobs"
+echo ""
+echo '# Check status with: qstat -u $USER'
+qstat -u "${USER}"

--- a/momemta/drell-yan/drell-yan_example.cxx
+++ b/momemta/drell-yan/drell-yan_example.cxx
@@ -106,23 +106,23 @@ int main(int argc, char** argv) {
     TChain chain(chainName.c_str());
     // Path needs to be findable inside of Docker container
     chain.Add(inputPath.c_str());
-    TTreeReader treeReader(&chain);
+    TTreeReader myReader(&chain);
 
     // TODO: serialize the 4-momentum into the TTree over just using branches
-    // TTreeReaderValue<LorentzVectorM> lep_plus_p4M(treeReader, "lep1_p4");
-    // TTreeReaderValue<LorentzVectorM> lep_minus_p4M(treeReader, "lep2_p4");
+    // TTreeReaderValue<LorentzVectorM> lep_plus_p4M(myReader, "lep1_p4");
+    // TTreeReaderValue<LorentzVectorM> lep_minus_p4M(myReader, "lep2_p4");
 
-    TTreeReaderValue<int> leading_lep_PID(treeReader, "lep1_PID");
+    TTreeReaderValue<int> leading_lep_PID(myReader, "lep1_PID");
 
-    TTreeReaderValue<float> lep_plus_Px(treeReader, "lep1_Px");
-    TTreeReaderValue<float> lep_plus_Py(treeReader, "lep1_Py");
-    TTreeReaderValue<float> lep_plus_Pz(treeReader, "lep1_Pz");
-    TTreeReaderValue<float> lep_plus_E(treeReader, "lep1_E");
+    TTreeReaderValue<float> lep_plus_Px(myReader, "lep1_Px");
+    TTreeReaderValue<float> lep_plus_Py(myReader, "lep1_Py");
+    TTreeReaderValue<float> lep_plus_Pz(myReader, "lep1_Pz");
+    TTreeReaderValue<float> lep_plus_E(myReader, "lep1_E");
 
-    TTreeReaderValue<float> lep_minus_Px(treeReader, "lep2_Px");
-    TTreeReaderValue<float> lep_minus_Py(treeReader, "lep2_Py");
-    TTreeReaderValue<float> lep_minus_Pz(treeReader, "lep2_Pz");
-    TTreeReaderValue<float> lep_minus_E(treeReader, "lep2_E");
+    TTreeReaderValue<float> lep_minus_Px(myReader, "lep2_Px");
+    TTreeReaderValue<float> lep_minus_Py(myReader, "lep2_Py");
+    TTreeReaderValue<float> lep_minus_Pz(myReader, "lep2_Pz");
+    TTreeReaderValue<float> lep_minus_E(myReader, "lep2_E");
 
     // Define output TTree, which will contain the weights we're computing (including uncertainty and computation time)
     std::unique_ptr<TTree> out_tree = std::make_unique<TTree>("momemta", "momemta");
@@ -143,7 +143,7 @@ int main(int argc, char** argv) {
     MoMEMta weight(configuration.freeze());
 
     // c.f. https://root.cern.ch/doc/v624/classTTreeReader.html#abe0530cfddbf50d5266d3d9ebb68972b
-    int totalNEvents = treeReader.GetEntries(true);
+    int totalNEvents = myReader.GetEntries(true);
     int fractionOfEvents = totalNEvents / 20;
 
     int counter = 0;
@@ -166,12 +166,12 @@ int main(int argc, char** argv) {
 
         // This call is usually followed by an iteration of the range using TTreeReader::Next(),
         // which will visit the the entries from begiNEntry to endEntry - 1.
-        treeReader.SetEntriesRange(steps.at(stepNumber), steps.at(stepNumber+1));
+        myReader.SetEntriesRange(steps.at(stepNumber), steps.at(stepNumber+1));
 
         counter = steps.at(stepNumber);
     }
 
-    while (treeReader.Next()) {
+    while (myReader.Next()) {
         /*
          * Prepare the LorentzVectors passed to MoMEMta:
          * In the input file they are written in the PtEtaPhiM<float> basis,
@@ -203,7 +203,7 @@ int main(int argc, char** argv) {
         weight_DY_err = weights.back().second;
         weight_DY_time = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
 
-        LOG(debug) << "Event " << treeReader.GetCurrentEntry() << " result: " << weight_DY << " +- " << weight_DY_err;
+        LOG(debug) << "Event " << myReader.GetCurrentEntry() << " result: " << weight_DY << " +- " << weight_DY_err;
         LOG(info) << "Weight computed in " << weight_DY_time << "ms";
 
         out_tree->Fill();

--- a/momemta/drell-yan/run_momemta.sh
+++ b/momemta/drell-yan/run_momemta.sh
@@ -46,8 +46,13 @@ cmake --build build \
 
 INPUT_PATH="${1:-/home/feickert/workarea/MadGraph5-simulation-configs/preprocessing/preprocessing_output.root}"
 OUTPUT_PATH="${2:-momemta_weights.root}"
+NUMBER_OF_STEPS="${3:-0}"
+# N.B.: STEP_NUMBER is 0 indexed
+STEP_NUMBER="${4:-0}"
 
 # Current configuration in drell_yan.cxx requires running from top level of example dir
 time ./build/drell-yan_example \
   --input "${INPUT_PATH}" \
-  --output "${OUTPUT_PATH}"
+  --output "${OUTPUT_PATH}" \
+  --nsteps "${NUMBER_OF_STEPS}" \
+  --step "${STEP_NUMBER}"

--- a/momemta/llbb/topology_llbb.cxx
+++ b/momemta/llbb/topology_llbb.cxx
@@ -181,8 +181,10 @@ int main(int argc, char** argv) {
         out_tree->Fill();
 
         ++counter;
-        if (counter % fractionOfEvents == 0)
-            std::cout << "calculated weights for " << counter << " events (" << counter*100/totalNEvents << "% of " << totalNEvents << " events)\n";
+        if (counter % fractionOfEvents == 0) {
+            std::cout << "calculated weights for " << counter << " events (" << std::round(counter*100./totalNEvents)
+            << "% of " << totalNEvents << " events)\n";
+        }
 
     }
     std::cout << "calculated weights for " << counter << " events\n";

--- a/momemta/llbb/topology_llbb.cxx
+++ b/momemta/llbb/topology_llbb.cxx
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <memory>
 #include <iostream>
+#include <stdlib.h>  // provide: exit, EXIT_FAILURE
 
 using LorentzVectorM = ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float>>;
 
@@ -40,6 +41,8 @@ int main(int argc, char** argv) {
     std::string outputPath;  // required input
     std::string configPath {"drell-yan_example.lua"};  // default value
     std::string chainName {"event_selection/hftree"};  // default value
+    int totalSteps {0};  // default value
+    int stepNumber {0};  // default value
     std::vector <std::string> unusedCLIArguments;
 
     for (int idx = 1; idx < argc; ++idx) {
@@ -73,9 +76,28 @@ int main(int argc, char** argv) {
                 configPath = argv[++idx];
             }
         }
+        // --nsteps
+        else if (std::string(argv[idx]) == "--nsteps") {
+            if (idx + 1 < argc) {
+                totalSteps = std::stoi(argv[++idx]);
+            }
+        }
+        // --step
+        else if (std::string(argv[idx]) == "--step") {
+            if (idx + 1 < argc) {
+                stepNumber = std::stoi(argv[++idx]);
+            }
+        }
         else {
             unusedCLIArguments.push_back(argv[idx]);
         }
+    }
+
+    if (totalSteps > 0 && (stepNumber == totalSteps)) {
+        std::cerr << "\n# ERROR: CLI arguments --nsteps and --step are the same: "
+        << "--nsteps " << totalSteps << " --step " << stepNumber << "\n"
+        << "This would result in an error so exiting now.\n" << std::endl;
+        exit(EXIT_FAILURE);
     }
 
     using std::swap;
@@ -137,6 +159,30 @@ int main(int argc, char** argv) {
     int fractionOfEvents = totalNEvents / 20;
 
     int counter = 0;
+
+    if (totalSteps > 0) {
+        std::vector<int> steps {};
+        int stepSize {
+            static_cast<int>( std::round(totalNEvents/static_cast<float>(totalSteps)) )
+        };
+
+        for (int n = 0; n < totalSteps; ++n)
+            steps.push_back(n*stepSize);
+        // push_back outside of the loop instead of using `n <= totalSteps` as
+        // there will probably be a non-integer unrounded step size, so make
+        // the last step big enough to get the remainder
+        steps.push_back(totalNEvents);
+
+        std::cout << "\n# calculating weights for event range: ("
+        << steps.at(stepNumber) << ", " << steps.at(stepNumber+1)-1 << ")\n" << std::endl;
+
+        // This call is usually followed by an iteration of the range using TTreeReader::Next(),
+        // which will visit the the entries from begiNEntry to endEntry - 1.
+        myReader.SetEntriesRange(steps.at(stepNumber), steps.at(stepNumber+1));
+
+        counter = steps.at(stepNumber);
+    }
+
     while (myReader.Next()) {
         /*
          * Prepare the LorentzVectors passed to MoMEMta:
@@ -187,7 +233,8 @@ int main(int argc, char** argv) {
         }
 
     }
-    std::cout << "calculated weights for " << counter << " events\n";
+    std::cout << "calculated weights for " << counter << " events (" << std::round(counter*100./totalNEvents)
+    << "% of " << totalNEvents << " events)\n";
 
     // Save output to TTree
     out_tree->SaveAs(outputPath.c_str());


### PR DESCRIPTION

```
* Parallelize MoMEMta across the NUMBER_OF_JOBS defined in bluewaters/run_momemta.sh
   - Each job is given information on the total number of jobs that have been requested and then what its job number is.
   - This information is passed through with `qsub -v` to set the environment variable values of NUMBER_OF_STEPS and STEP_NUMBER in the PBS job
* Add CLI accessible variables to the C++ code that allow for the job to determine what event range in the input ROOT file it should be running over given information from NUMBER_OF_STEPS and STEP_NUMBER in the PBS job
   - The number of events are split up into NUMBER_OF_STEPS roughly equal slices of events.
   - The job then selects the STEP_NUMBER slice and rus MoMEMta over those events
   - This allows for scaling of running MoMEMta out across the number of jobs available
* Add security check if NUMBER_OF_STEPS or STEP_NUMBER are not set
```