### PR TITLE
feat: Parallelize simulation pipeline

### DIFF
--- a/bluewaters/drell-yan_ll/delphes.pbs
+++ b/bluewaters/drell-yan_ll/delphes.pbs
@@ -6,7 +6,7 @@
 #PBS -l nodes=1:ppn=16:xe
 
 # Set the wallclock time
-#PBS -l walltime=3:00:00
+#PBS -l walltime=1:00:00
 
 # Use shifter queue
 #PBS -l gres=shifter
@@ -18,26 +18,31 @@
 #PBS -e "${PBS_JOBNAME}.${PBS_JOBID}.err"
 #PBS -o "${PBS_JOBNAME}.${PBS_JOBID}.out"
 
-# Set email notification on termination or abort
-#PBS -m ea
+# Set email notification on termination (e) or abort (a)
+#PBS -m a
 #PBS -M matthew.feickert@cern.ch
 
 # Set allocation to charge
 #PBS -A bbdz
 
+# Ensure modern bash
+module load bash
 # Ensure shifter enabled
 module load shifter
 
-PHYSICS_PROCESS="drell-yan_llbb"
-INPUT_JOBID="12509809.bw"
+TOPOLOGY="ll"
+PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"
 
 USER_SCRATCH="/mnt/c/scratch/sciteam/${USER}"
 OUTPUT_BASE_PATH="${USER_SCRATCH}/${PHYSICS_PROCESS}/${PBS_JOBNAME}"
 OUTPUT_PATH="${OUTPUT_BASE_PATH}/${PBS_JOBID}"
 mkdir -p "${OUTPUT_PATH}"
 
-# INPUT_FILE_PATH="/mnt/c/scratch/sciteam/${USER}/${PHYSICS_PROCESS}/madgraph/nevents_10e4_run/Events/run_01/tag_1_pythia8_events.hepmc"
-INPUT_FILE_PATH="${USER_SCRATCH}/${PHYSICS_PROCESS}/madgraph/${INPUT_JOBID}/drell-yan_llbb_output/Events/run_01/tag_1_pythia8_events.hepmc"
+# INPUT_FILE_PATH passed through by qsub -v in run_delphes.sh
+if [ -z "${INPUT_FILE_PATH}" ]; then
+  echo "# ERROR: Variable INPUT_FILE_PATH is required to be set"
+  exit 1
+fi
 
 # $HOME is /u/sciteam/${USER}
 SHIFTER_IMAGE="scailfin/delphes-python-centos:3.5.0"
@@ -48,6 +53,9 @@ shifterimg pull "${SHIFTER_IMAGE}"
 # Delphes Docker image and give a symbol lookup error.
 # c.f. https://bluewaters.ncsa.illinois.edu/shifter#remarks-on-running-apps
 # c.f. https://jira.ncsa.illinois.edu/browse/BWAPPS-7234
+# Note also that INPUT_FILE_PATH is going to be either a .hepmc.gz or a .hepmc
+# and the file extension is determined by what is available when run_delphes.sh
+# is run
 aprun \
   --bypass-app-transfer \
   --pes-per-node 1 \
@@ -57,12 +65,14 @@ aprun \
     --image="${SHIFTER_IMAGE}" \
     --volume="${OUTPUT_PATH}":/root/data \
     --volume=/mnt/a/"${HOME}":/mnt/a/"${HOME}" \
+    --env INPUT_FILE_PATH="${INPUT_FILE_PATH}" \
     --workdir=/root/data \
     -- /bin/bash -c 'export LD_LIBRARY_PATH=$(echo -e "${LD_LIBRARY_PATH//\:/\\n}" | grep -v /opt/cray/nvidia/390.46-1_1.0502.2481.1.1.gem/lib64 | tr "\n" ":") && \
         export PATH="/usr/local/venv/bin:${PATH}" && \
         printf "\n# printenv:\n" && printenv && printf "\n\n" && \
-        if [ -f '"${INPUT_FILE_PATH}"'.gz ]; then gunzip '"${INPUT_FILE_PATH}"'.gz; fi && \
+        printf "# Unzip HEPMC file if needed\n\n" && \
+        if [ -f "${INPUT_FILE_PATH::-3}.gz" ]; then export INPUT_FILE_PATH="${INPUT_FILE_PATH::-3}"; gunzip "${INPUT_FILE_PATH}.gz"; fi && \
         DelphesHepMC2 \
         /usr/local/venv/cards/delphes_card_ATLAS.tcl \
         delphes_output.root \
-        '"${INPUT_FILE_PATH}"
+        "${INPUT_FILE_PATH}"'

--- a/bluewaters/drell-yan_ll/madgraph5.pbs
+++ b/bluewaters/drell-yan_ll/madgraph5.pbs
@@ -40,6 +40,8 @@ mkdir -p "${OUTPUT_PATH}"
 
 CODE_BASE_PATH="/mnt/a/${HOME}/MadGraph5-simulation-configs"
 
+# Ensure modern bash
+module load bash
 # Ensure shifter enabled
 module load shifter
 
@@ -55,12 +57,16 @@ aprun \
     --image="${SHIFTER_IMAGE}" \
     --volume="${OUTPUT_PATH}":/root/data \
     --volume=/mnt/a/"${HOME}":/mnt/a/"${HOME}" \
+    --env CODE_BASE_PATH="${CODE_BASE_PATH}" \
+    --env CONFIG_NAME="${CONFIG_NAME}" \
+    --env PHYSICS_PROCESS="${PHYSICS_PROCESS}" \
+    --env RANDOM_SEED="${RANDOM_SEED}" \
     --workdir=/root/data \
     -- /bin/bash -c 'export PATH="/usr/local/venv/bin:${PATH}" && \
         printf "\n# printenv:\n" && printenv && printf "\n\n" && \
-        python '"${CODE_BASE_PATH}"'/generate_config.py --help && \
+        python "${CODE_BASE_PATH}"/generate_config.py --help && \
         echo "" && \
-        python '"${CODE_BASE_PATH}"'/generate_config.py -c '"${CODE_BASE_PATH}"'/configs/json/'"${CONFIG_NAME}"' --outpath $PWD --seed '"${RANDOM_SEED}"' && \
-        cat '"${PHYSICS_PROCESS}"'.mg5 && \
+        python "${CODE_BASE_PATH}"/generate_config.py -c "${CODE_BASE_PATH}/configs/json/${CONFIG_NAME}" --outpath $PWD --seed "${RANDOM_SEED}" && \
+        cat "${PHYSICS_PROCESS}".mg5 && \
         echo "" && \
-        mg5_aMC '"${PHYSICS_PROCESS}"'.mg5'
+        mg5_aMC "${PHYSICS_PROCESS}".mg5'

--- a/bluewaters/drell-yan_ll/momemta.pbs
+++ b/bluewaters/drell-yan_ll/momemta.pbs
@@ -64,13 +64,19 @@ aprun \
     --image="${SHIFTER_IMAGE}" \
     --volume="${OUTPUT_PATH}":/root/data \
     --volume=/mnt/a/"${HOME}":/mnt/a/"${HOME}" \
+    --env PHYSICS_PROCESS="${PHYSICS_PROCESS}" \
+    --env CODE_BASE_PATH="${CODE_BASE_PATH}" \
+    --env INPUT_PATH="${INPUT_PATH}" \
+    --env OUTPUT_FILE="${OUTPUT_FILE}" \
+    --env NUMBER_OF_STEPS="${NUMBER_OF_STEPS}" \
+    --env STEP_NUMBER="${STEP_NUMBER}" \
     --workdir=/root/data \
     -- /bin/bash -c 'source scl_source enable devtoolset-8 && \
         export PATH="/usr/local/venv/bin:${PATH}" && \
         printf "\n# printenv:\n" && printenv && printf "\n\n" && \
-        mkdir -p momemta/'"${PHYSICS_PROCESS}"' && \
+        mkdir -p momemta/"${PHYSICS_PROCESS}" && \
         mkdir -p configs/momemta/ && \
-        cp -r '"${CODE_BASE_PATH}"'/momemta/'"${PHYSICS_PROCESS}"'/ momemta/ && \
-        cp -r '"${CODE_BASE_PATH}"'/configs/momemta/ configs/ && \
-        cd momemta/'"${PHYSICS_PROCESS}"' && \
-        bash run_momemta.sh '"${INPUT_PATH}"' '"${OUTPUT_FILE}"' '"${NUMBER_OF_STEPS}"' '"${STEP_NUMBER}"
+        cp -r "${CODE_BASE_PATH}/momemta/${PHYSICS_PROCESS}"/ momemta/ && \
+        cp -r "${CODE_BASE_PATH}"/configs/momemta/ configs/ && \
+        cd momemta/"${PHYSICS_PROCESS}" && \
+        bash run_momemta.sh "${INPUT_PATH}" "${OUTPUT_FILE}" "${NUMBER_OF_STEPS}" "${STEP_NUMBER}"'

--- a/bluewaters/drell-yan_ll/preprocessing.pbs
+++ b/bluewaters/drell-yan_ll/preprocessing.pbs
@@ -5,7 +5,7 @@
 #PBS -l nodes=1:ppn=8:xk
 
 # Set the wallclock time
-#PBS -l walltime=24:00:00
+#PBS -l walltime=1:00:00
 
 # Use shifter queue
 #PBS -l gres=shifter
@@ -17,8 +17,8 @@
 #PBS -e "${PBS_JOBNAME}.${PBS_JOBID}.err"
 #PBS -o "${PBS_JOBNAME}.${PBS_JOBID}.out"
 
-# Set email notification on termination or abort
-#PBS -m ea
+# Set email notification on termination (e) or abort (a)
+#PBS -m a
 #PBS -M matthew.feickert@cern.ch
 
 # Set allocation to charge
@@ -27,8 +27,8 @@
 # Ensure shifter enabled
 module load shifter
 
-PHYSICS_PROCESS="drell-yan_llbb"
-INPUT_JOBID="12509845.bw"
+TOPOLOGY="ll"
+PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"
 CODE_BASE_PATH="/mnt/a/${HOME}/MadGraph5-simulation-configs"
 
 USER_SCRATCH="/mnt/c/scratch/sciteam/${USER}"
@@ -40,8 +40,11 @@ mkdir -p "${OUTPUT_PATH}"
 SHIFTER_IMAGE="scailfin/delphes-python-centos:3.5.0"
 shifterimg pull "${SHIFTER_IMAGE}"
 
-# INPUT_PATH="/mnt/c/scratch/sciteam/${USER}/${PHYSICS_PROCESS}/delphes/nevents_10e4/delphes_output.root"
-INPUT_FILE="${USER_SCRATCH}/${PHYSICS_PROCESS}/delphes/${INPUT_JOBID}/delphes_output.root"
+# INPUT_FILE passed through by qsub -v in run_delphes.sh
+if [ -z "${INPUT_FILE}" ]; then
+  echo "# ERROR: Variable INPUT_FILE is required to be set"
+  exit 1
+fi
 OUTPUT_FILE="preprocessing_output.root"
 
 # The need to edit the contents of LD_LIBRARY_PATH is to remove NVIDIA libraries
@@ -58,10 +61,14 @@ aprun \
     --image="${SHIFTER_IMAGE}" \
     --volume="${OUTPUT_PATH}":/root/data \
     --volume=/mnt/a/"${HOME}":/mnt/a/"${HOME}" \
+    --env CODE_BASE_PATH="${CODE_BASE_PATH}" \
+    --env INPUT_FILE="${INPUT_FILE}" \
+    --env OUTPUT_PATH="${OUTPUT_PATH}" \
+    --env OUTPUT_FILE="${OUTPUT_FILE}" \
     --workdir=/root/data \
     -- /bin/bash -c 'export LD_LIBRARY_PATH=$(echo -e "${LD_LIBRARY_PATH//\:/\\n}" | grep -v /opt/cray/nvidia/390.46-1_1.0502.2481.1.1.gem/lib64 | tr "\n" ":") && \
         export PATH="/usr/local/venv/bin:${PATH}" && \
         printf "\n# printenv:\n" && printenv && printf "\n\n" && \
-        cp -r '"${CODE_BASE_PATH}"'/preprocessing '"${OUTPUT_PATH}"' && \
+        cp -r "${CODE_BASE_PATH}"/preprocessing "${OUTPUT_PATH}" && \
         cd preprocessing && \
-        bash run_preprocessing.sh '"${INPUT_FILE}"' '"${OUTPUT_FILE}"
+        time bash run_preprocessing.sh "${INPUT_FILE}" "${OUTPUT_FILE}"'

--- a/bluewaters/run_delphes.sh
+++ b/bluewaters/run_delphes.sh
@@ -6,5 +6,28 @@ if [ "${BASH_VERSION:0:1}" -lt 4 ]; then
     exit 1
 fi
 
-PROCESS_DIRECTORY="${1:-drell-yan_ll}"
-qsub "${PROCESS_DIRECTORY}/delphes.pbs"
+TOPOLOGY="ll"
+PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"
+PROCESS_DIRECTORY="${1:-${PHYSICS_PROCESS}}"
+
+USER_SCRATCH="/mnt/c/scratch/sciteam/${USER}"
+OUTPUT_BASE_PATH="${USER_SCRATCH}/${PHYSICS_PROCESS}"
+
+if [ -f hepmc_filelist.txt ]; then
+    rm hepmc_filelist.txt
+fi
+# If the .hepmc.gz file has been unzipped already then it no longer exists and just the .hepmc file remains
+find "${OUTPUT_BASE_PATH}"/madgraph/*/"${PHYSICS_PROCESS}"_output/Events/run_01/ -name "tag_1_pythia8_events.hepmc*" | sort > hepmc_filelist.txt
+
+echo "# Submitting $(wc -l hepmc_filelist.txt | awk '{print $1}') jobs"
+echo ""
+while IFS="" read -r line || [ -n "${line}" ]
+do
+    # qsub -v: comma separated list of strings of the form variable or variable=value.
+    qsub -v INPUT_FILE_PATH="${line}" "${PROCESS_DIRECTORY}/delphes.pbs"
+done < hepmc_filelist.txt
+echo ""
+echo "# Submitted $(wc -l hepmc_filelist.txt | awk '{print $1}') jobs"
+echo ""
+echo '# Check status with: qstat -u $USER'
+qstat -u "${USER}"

--- a/bluewaters/run_preprocessing.sh
+++ b/bluewaters/run_preprocessing.sh
@@ -7,4 +7,30 @@ if [ "${BASH_VERSION:0:1}" -lt 4 ]; then
 fi
 
 PROCESS_DIRECTORY="${1:-drell-yan_ll}"
-qsub "${PROCESS_DIRECTORY}/preprocessing.pbs"
+# qsub "${PROCESS_DIRECTORY}/preprocessing.pbs"
+
+TOPOLOGY="ll"
+PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"
+PROCESS_DIRECTORY="${1:-${PHYSICS_PROCESS}}"
+
+USER_SCRATCH="/mnt/c/scratch/sciteam/${USER}"
+OUTPUT_BASE_PATH="${USER_SCRATCH}/${PHYSICS_PROCESS}"
+
+if [ -f delphes_filelist.txt ]; then
+    rm delphes_filelist.txt
+fi
+
+find "${OUTPUT_BASE_PATH}"/delphes/*/ -name "delphes_output.root" | sort > delphes_filelist.txt
+
+echo "# Submitting $(wc -l delphes_filelist.txt | awk '{print $1}') jobs"
+echo ""
+while IFS="" read -r line || [ -n "${line}" ]
+do
+    # qsub -v: comma separated list of strings of the form variable or variable=value.
+    qsub -v INPUT_FILE="${line}" "${PROCESS_DIRECTORY}/preprocessing.pbs"
+done < delphes_filelist.txt
+echo ""
+echo "# Submitted $(wc -l delphes_filelist.txt | awk '{print $1}') jobs"
+echo ""
+echo '# Check status with: qstat -u $USER'
+qstat -u "${USER}"

--- a/bluewaters/run_preprocessing.sh
+++ b/bluewaters/run_preprocessing.sh
@@ -7,7 +7,6 @@ if [ "${BASH_VERSION:0:1}" -lt 4 ]; then
 fi
 
 PROCESS_DIRECTORY="${1:-drell-yan_ll}"
-# qsub "${PROCESS_DIRECTORY}/preprocessing.pbs"
 
 TOPOLOGY="ll"
 PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"


### PR DESCRIPTION
```
* Run the simulation pipeline in parallel by splitting up the initial jobs and then recombinng only after the preprocessing stage
   - Have the Delphes stage iterate over all previous runs from the MadGraph5+PYTHIA8 stage
   - Have the preprocessing stage iterate over all previous runs from the Delphes stage
* Use Shifter env option to pass environment variables into Shifter container
   - Avoid needing to string escape between hard (' ') and soft (" ") quotes
* Load bash module to ensure ~modern Bash (Bash v4)
* Add default value checks for environmental variables passed through qsub
```