### PR TITLE
feat: Add preprocessing combination script

### DIFF
--- a/bluewaters/combine_preprocessing.sh
+++ b/bluewaters/combine_preprocessing.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "${BASH_VERSION:0:1}" -lt 4 ]; then
+    echo "ERROR: This script uses Bash version 4.0+ syntax. Your Bash version is ${BASH_VERSION} which is too old."
+    echo "       Run: 'module load bash' to get a modern version on Blue Waters."
+    exit 1
+fi
+
+PROCESS_DIRECTORY="${1:-drell-yan_ll}"
+
+qsub "${PROCESS_DIRECTORY}/combine_preprocessing.pbs"
+echo ""
+echo '# Check status with: qstat -u $USER'
+qstat -u "${USER}"

--- a/bluewaters/drell-yan_ll/combine_preprocessing.pbs
+++ b/bluewaters/drell-yan_ll/combine_preprocessing.pbs
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Set the number of processing elements (PEs) or cores
+# Set the number of PEs per node
+#PBS -l nodes=1:ppn=8:xk
+
+# Set the wallclock time
+#PBS -l walltime=0:10:00
+
+# Use shifter queue
+#PBS -l gres=shifter
+
+# Set the PBS_JOBNAME
+#PBS -N preprocessing
+
+# Set the job stdout and stderr
+#PBS -e "${PBS_JOBNAME}.${PBS_JOBID}.err"
+#PBS -o "${PBS_JOBNAME}.${PBS_JOBID}.out"
+
+# Set email notification on termination (e) or abort (a)
+#PBS -m a
+#PBS -M matthew.feickert@cern.ch
+
+# Set allocation to charge
+#PBS -A bbdz
+
+# Ensure modern bash
+module load bash
+# Ensure shifter enabled
+module load shifter
+
+TOPOLOGY="ll"
+PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"
+
+USER_SCRATCH="/mnt/c/scratch/sciteam/${USER}"
+OUTPUT_BASE_PATH="${USER_SCRATCH}/${PHYSICS_PROCESS}/${PBS_JOBNAME}"
+OUTPUT_PATH="${OUTPUT_BASE_PATH}"
+mkdir -p "${OUTPUT_PATH}"
+
+# $HOME is /u/sciteam/${USER}
+SHIFTER_IMAGE="scailfin/delphes-python-centos:3.5.0"
+shifterimg pull "${SHIFTER_IMAGE}"
+
+aprun \
+  --bypass-app-transfer \
+  --pes-per-node 1 \
+  --cpu-binding none \
+  -- shifter \
+    --clearenv \
+    --image="${SHIFTER_IMAGE}" \
+    --volume="${OUTPUT_PATH}":/root/data \
+    --volume=/mnt/a/"${HOME}":/mnt/a/"${HOME}" \
+    --workdir=/root/data \
+    -- /bin/bash -c 'source scl_source enable devtoolset-8 && \
+        export PATH="/usr/local/venv/bin:${PATH}" && \
+        printf "\n# printenv:\n" && printenv && printf "\n\n" && \
+        printf "\n# hadd all the ROOT files together:\n" && \
+        find ./*/preprocessing -name "preprocessing_output.root" | sort | grep --invert-match "combined\|nevents" > sorted_file_list.txt && \
+        cat sorted_file_list.txt | xargs hadd -f -j $(($(nproc) - 1)) combined_preprocessing_output.root && \
+        wc -l sorted_file_list.txt && \
+        rm sorted_file_list.txt'

--- a/bluewaters/run_preprocessing.sh
+++ b/bluewaters/run_preprocessing.sh
@@ -6,8 +6,6 @@ if [ "${BASH_VERSION:0:1}" -lt 4 ]; then
     exit 1
 fi
 
-PROCESS_DIRECTORY="${1:-drell-yan_ll}"
-
 TOPOLOGY="ll"
 PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"
 PROCESS_DIRECTORY="${1:-${PHYSICS_PROCESS}}"


### PR DESCRIPTION
As a compliment to PR #20, this PR adds a script that will gather and combine all the output of the preprocessing runs into a single ROOT file and takes advantage of the `hadd` `-j` option

```
-j Parallelize the execution in multiple processes
```

This PR is similar to PR #17

```
* Add combination script for job that uses ROOT's `hadd` to combine all the ROOT output files from the preprocessing stage into a single ROOT file
   - Use hadd -j option to parallelize the execution in multiple processes
* Add user level submission script
```