### PR TITLE
chore: Add `time` to commands and load bash as a module

### DIFF
--- a/bluewaters/drell-yan_ll/combine_momemta.pbs
+++ b/bluewaters/drell-yan_ll/combine_momemta.pbs
@@ -27,7 +27,7 @@
 # Ensure shifter enabled
 module load shifter
 
-TOPOLOGY="llbb"
+TOPOLOGY="ll"
 PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"
 
 USER_SCRATCH="/mnt/c/scratch/sciteam/${USER}"

--- a/bluewaters/drell-yan_ll/delphes.pbs
+++ b/bluewaters/drell-yan_ll/delphes.pbs
@@ -6,7 +6,7 @@
 #PBS -l nodes=1:ppn=16:xe
 
 # Set the wallclock time
-#PBS -l walltime=1:00:00
+#PBS -l walltime=0:30:00
 
 # Use shifter queue
 #PBS -l gres=shifter
@@ -72,7 +72,7 @@ aprun \
         printf "\n# printenv:\n" && printenv && printf "\n\n" && \
         printf "# Unzip HEPMC file if needed\n\n" && \
         if [ -f "${INPUT_FILE_PATH::-3}.gz" ]; then export INPUT_FILE_PATH="${INPUT_FILE_PATH::-3}"; gunzip "${INPUT_FILE_PATH}.gz"; fi && \
-        DelphesHepMC2 \
+        time DelphesHepMC2 \
         /usr/local/venv/cards/delphes_card_ATLAS.tcl \
         delphes_output.root \
         "${INPUT_FILE_PATH}"'

--- a/bluewaters/drell-yan_ll/delphes.pbs
+++ b/bluewaters/drell-yan_ll/delphes.pbs
@@ -6,7 +6,7 @@
 #PBS -l nodes=1:ppn=16:xe
 
 # Set the wallclock time
-#PBS -l walltime=0:30:00
+#PBS -l walltime=0:45:00
 
 # Use shifter queue
 #PBS -l gres=shifter

--- a/bluewaters/drell-yan_ll/madgraph5.pbs
+++ b/bluewaters/drell-yan_ll/madgraph5.pbs
@@ -5,7 +5,7 @@
 #PBS -l nodes=1:ppn=8:xk
 
 # Set the wallclock time
-#PBS -l walltime=6:00:00
+#PBS -l walltime=1:00:00
 
 # Use shifter queue
 #PBS -l gres=shifter
@@ -69,4 +69,4 @@ aprun \
         python "${CODE_BASE_PATH}"/generate_config.py -c "${CODE_BASE_PATH}/configs/json/${CONFIG_NAME}" --outpath $PWD --seed "${RANDOM_SEED}" && \
         cat "${PHYSICS_PROCESS}".mg5 && \
         echo "" && \
-        mg5_aMC "${PHYSICS_PROCESS}".mg5'
+        time mg5_aMC "${PHYSICS_PROCESS}".mg5'

--- a/bluewaters/drell-yan_ll/momemta.pbs
+++ b/bluewaters/drell-yan_ll/momemta.pbs
@@ -24,13 +24,14 @@
 # Set allocation to charge
 #PBS -A bbdz
 
+# Ensure modern bash
+module load bash
 # Ensure shifter enabled
 module load shifter
 
-TOPOLOGY="llbb"
+TOPOLOGY="ll"
 PHYSICS_PROCESS="drell-yan_${TOPOLOGY}"
-INPUT_JOBID="12513059.bw"
-CODE_BASE_PATH="/mnt/a/${HOME}/MadGraph5-simulation-configs"
+CODE_BASE_PATH="/mnt/a/u/sciteam/${USER}/MadGraph5-simulation-configs"
 
 USER_SCRATCH="/mnt/c/scratch/sciteam/${USER}"
 OUTPUT_BASE_PATH="${USER_SCRATCH}/${PHYSICS_PROCESS}/${PBS_JOBNAME}"
@@ -41,7 +42,7 @@ mkdir -p "${OUTPUT_PATH}"
 SHIFTER_IMAGE="neubauergroup/bluewaters-momemta:1.0.1"
 shifterimg pull "${SHIFTER_IMAGE}"
 
-INPUT_PATH="${USER_SCRATCH}/${PHYSICS_PROCESS}/preprocessing/${INPUT_JOBID}/preprocessing/preprocessing_output.root"
+INPUT_PATH="${USER_SCRATCH}/${PHYSICS_PROCESS}/preprocessing/combined_preprocessing_output.root"
 
 OUTPUT_FILE="${OUTPUT_PATH}/momemta_weights.root"
 
@@ -79,4 +80,4 @@ aprun \
         cp -r "${CODE_BASE_PATH}/momemta/${PHYSICS_PROCESS}"/ momemta/ && \
         cp -r "${CODE_BASE_PATH}"/configs/momemta/ configs/ && \
         cd momemta/"${PHYSICS_PROCESS}" && \
-        bash run_momemta.sh "${INPUT_PATH}" "${OUTPUT_FILE}" "${NUMBER_OF_STEPS}" "${STEP_NUMBER}"'
+        time bash run_momemta.sh "${INPUT_PATH}" "${OUTPUT_FILE}" "${NUMBER_OF_STEPS}" "${STEP_NUMBER}"'

--- a/bluewaters/drell-yan_ll/preprocessing.pbs
+++ b/bluewaters/drell-yan_ll/preprocessing.pbs
@@ -5,7 +5,7 @@
 #PBS -l nodes=1:ppn=8:xk
 
 # Set the wallclock time
-#PBS -l walltime=1:00:00
+#PBS -l walltime=0:30:00
 
 # Use shifter queue
 #PBS -l gres=shifter
@@ -24,6 +24,8 @@
 # Set allocation to charge
 #PBS -A bbdz
 
+# Ensure modern bash
+module load bash
 # Ensure shifter enabled
 module load shifter
 

--- a/bluewaters/drell-yan_ll/preprocessing.pbs
+++ b/bluewaters/drell-yan_ll/preprocessing.pbs
@@ -5,7 +5,7 @@
 #PBS -l nodes=1:ppn=8:xk
 
 # Set the wallclock time
-#PBS -l walltime=0:30:00
+#PBS -l walltime=0:45:00
 
 # Use shifter queue
 #PBS -l gres=shifter


### PR DESCRIPTION
```
* Change topology to ll Drell-Yan for simple baseline tests
* Set walltime to 1 hour for MadGraph jobs
* Set walltime to 45 minutes for Delphes and preprocessing jobs
* Load bash as a module to ensure modern enough release
* Update MoMEMta input paths
* Add time to commands to get run lengths in logs
```