### PR TITLE
feat: Add cuts option to JSON config

### DIFF
--- a/bluewaters/run_madgraph5.sh
+++ b/bluewaters/run_madgraph5.sh
@@ -9,7 +9,7 @@ fi
 PROCESS_DIRECTORY="${1:-drell-yan_ll}"
 TOTAL_NEVENTS=1000000
 # This should be taken from the JSON config
-EVENTS_PER_JOB=10000
+EVENTS_PER_JOB=5000
 
 # build seed array
 n_jobs=$(("${TOTAL_NEVENTS}" / "${EVENTS_PER_JOB}"))

--- a/configs/json/drell-yan_ll.json
+++ b/configs/json/drell-yan_ll.json
@@ -8,8 +8,12 @@
     },
     "run": {
       "shower": "Pythia8",
-      "nevents": 10000,
-      "iseed": 0
+      "nevents": 5000,
+      "iseed": 0,
+      "cuts": {
+        "ptl": 25,
+        "etal": 2.5
+      }
     }
   },
   "version": "0.1.0"

--- a/generate_config.py
+++ b/generate_config.py
@@ -36,6 +36,12 @@ def json_to_mg5(config):
     iseed = run_options.get("iseed", 0)
     mg5_str += "\n  # Set random seed"
     mg5_str += f"\n  set iseed {iseed}"
+
+    if "cuts" in run_options:
+        mg5_str += "\n  # Set cut values"
+        for cut, cut_value in run_options["cuts"].items():
+            mg5_str += f"\n  set {cut} {cut_value}"
+
     mg5_str += "\n"
 
     return mg5_str


### PR DESCRIPTION
```
* Add option for run card cuts in the JSON config
* Change number of events in MadGraph jobs to be 5000 to increase parallelism on cluster
```